### PR TITLE
Use available owner methods

### DIFF
--- a/vendor/patch-generate-controller/index.js
+++ b/vendor/patch-generate-controller/index.js
@@ -14,7 +14,7 @@ function generateControllerFactory(owner, controllerName, context) {
 
   let factoryName = `controller:${controllerType}`;
 
-  let Factory = owner._lookupFactory(factoryName).extend({
+  let Factory = owner.lookupFactory(factoryName).extend({
     isGenerated: true,
     toString() {
       return `(generated ${controllerName} controller)`;
@@ -23,7 +23,7 @@ function generateControllerFactory(owner, controllerName, context) {
 
   let fullName = `controller:${controllerName}`;
 
-  owner.register(fullName, Factory);
+  owner.registry.register(fullName, Factory);
 
   return Factory;
 }


### PR DESCRIPTION
`_lookupFactory` and `register` methods are not available in the owner object. Replacing them with `lookupFactory` and `registry.register`